### PR TITLE
Implement the basic case of nil pointer dereference 

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,0 +1,33 @@
+name: Go
+
+on:
+  push:
+    branches: [ develop ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+
+    - name: Set up Go 1.x
+      uses: actions/setup-go@v2
+      with:
+        go-version: ^1.13
+      id: go
+
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v2
+
+    - name: Get dependencies
+      run: |
+        go get -v -t -d ./...
+
+    - name: Build
+      run: go build -v .
+
+    - name: Test
+      run: go test -v .

--- a/README.md
+++ b/README.md
@@ -1,0 +1,46 @@
+# niller
+niller (nil + killer) is a static analysis tool that warns dangerous statement involving nil.
+
+# Example 
+```go
+package a
+
+import "errors"
+
+type Test struct {}
+
+func (t *Test) test() int { return 1 }
+
+func CreateTest(cond bool) (*Test, error) {
+	if cond {
+		return &Test{}, nil
+	} else {
+		return nil, errors.New("err")
+	}
+}
+
+func f() interface{} {
+	var a = &Test{}
+	var b *Test
+	c, _ := CreateTest(true)
+	d, err := CreateTest(true)
+	if err != nil {
+		return err
+	}
+	var e *Test
+	if e, err = CreateTest(true); err != nil {
+		return err
+	}
+	var (
+		f *Test
+	)
+
+	a.test()
+	b.test() // warns "b may be nil"
+	c.test() // warns "c may be nil"
+	d.test()
+	e.test()
+	f.test() // warns "f may be nil"
+	return nil
+}
+```

--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@ package a
 
 import "errors"
 
-type Test struct {}
+type Test struct { val int }
 
-func (t *Test) test() int { return 1 }
+func (t *Test) test() int { return t.val }
 
 func CreateTest(cond bool) (*Test, error) {
 	if cond {

--- a/cmd/niller/main.go
+++ b/cmd/niller/main.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"golang.org/x/tools/go/analysis/unitchecker"
-	"uaa"
+	"niller"
 )
 
-func main() { unitchecker.Main(uaa.Analyzer) }
+func main() { unitchecker.Main(niller.Analyzer) }

--- a/cmd/uaa/main.go
+++ b/cmd/uaa/main.go
@@ -1,9 +1,8 @@
 package main
 
 import (
-	"uaa"
 	"golang.org/x/tools/go/analysis/unitchecker"
+	"uaa"
 )
 
 func main() { unitchecker.Main(uaa.Analyzer) }
-

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module uaa
+module niller
 
 go 1.14
 

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module uaa
 
 go 1.14
 
-require golang.org/x/tools v0.0.0-20200831203904-5a2aa26beb65
+require golang.org/x/tools v0.0.0-20200902012652-d1954cc86c82

--- a/go.sum
+++ b/go.sum
@@ -14,8 +14,8 @@ golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
-golang.org/x/tools v0.0.0-20200831203904-5a2aa26beb65 h1:DajXNh69ob79PCQz1N7OHxmqq6ASZC5xAnJJWIQGR6I=
-golang.org/x/tools v0.0.0-20200831203904-5a2aa26beb65/go.mod h1:Cj7w3i3Rnn0Xh82ur9kSqwfTHTeVxaDqrfMjpcNT6bE=
+golang.org/x/tools v0.0.0-20200902012652-d1954cc86c82 h1:shxDsb9Dz27xzk3A0DxP0JuJnZMpKrdg8+E14eiUAX4=
+golang.org/x/tools v0.0.0-20200902012652-d1954cc86c82/go.mod h1:Cj7w3i3Rnn0Xh82ur9kSqwfTHTeVxaDqrfMjpcNT6bE=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 h1:go1bK/D/BFZV2I8cIQd1NKEZ+0owSTG1fDTci4IqFcE=

--- a/niller.go
+++ b/niller.go
@@ -1,4 +1,4 @@
-package uaa
+package niller
 
 import (
 	"go/ast"
@@ -9,11 +9,11 @@ import (
 	"golang.org/x/tools/go/ast/inspector"
 )
 
-const doc = "uaa is ..."
+const doc = "niller is ..."
 
 // Analyzer is ...
 var Analyzer = &analysis.Analyzer{
-	Name: "uaa",
+	Name: "niller",
 	Doc:  doc,
 	Run:  run,
 	Requires: []*analysis.Analyzer{

--- a/niller_test.go
+++ b/niller_test.go
@@ -1,9 +1,9 @@
-package uaa_test
+package niller_test
 
 import (
 	"testing"
 
-	"uaa"
+	"niller"
 
 	"golang.org/x/tools/go/analysis/analysistest"
 )
@@ -11,5 +11,5 @@ import (
 // TestAnalyzer is a test for Analyzer.
 func TestAnalyzer(t *testing.T) {
 	testdata := analysistest.TestData()
-	analysistest.Run(t, testdata, uaa.Analyzer, "a")
+	analysistest.Run(t, testdata, niller.Analyzer, "a")
 }

--- a/plugin/main.go
+++ b/plugin/main.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 
 	"golang.org/x/tools/go/analysis"
-	"uaa"
+	"niller"
 )
 
 // flags for Analyzer.Flag.
@@ -24,12 +24,12 @@ type analyzerPlugin struct{}
 
 func (analyzerPlugin) GetAnalyzers() []*analysis.Analyzer {
 	if flags != "" {
-		flagset := uaa.Analyzer.Flags
+		flagset := niller.Analyzer.Flags
 		if err := flagset.Parse(strings.Split(flags, " ")); err != nil {
-			panic("cannot parse flags of uaa: " + err.Error())
+			panic("cannot parse flags of niller: " + err.Error())
 		}
 	}
 	return []*analysis.Analyzer{
-		uaa.Analyzer,
+		niller.Analyzer,
 	}
 }

--- a/plugin/main.go
+++ b/plugin/main.go
@@ -7,8 +7,8 @@ package main
 import (
 	"strings"
 
-	"uaa"
 	"golang.org/x/tools/go/analysis"
+	"uaa"
 )
 
 // flags for Analyzer.Flag.
@@ -33,4 +33,3 @@ func (analyzerPlugin) GetAnalyzers() []*analysis.Analyzer {
 		uaa.Analyzer,
 	}
 }
-

--- a/plugin/main.go
+++ b/plugin/main.go
@@ -1,5 +1,5 @@
 // This file can build as a plugin for golangci-lint by below command.
-//    go build -buildmode=plugin -o path_to_plugin_dir uaa/plugin/uaa
+//    go build -buildmode=plugin -o path_to_plugin_dir niller/plugin/niller
 // See: https://golangci-lint.run/contributing/new-linters/#how-to-add-a-private-linter-to-golangci-lint
 
 package main
@@ -13,7 +13,7 @@ import (
 
 // flags for Analyzer.Flag.
 // If you would like to specify flags for your plugin, you can put them via 'ldflags' as below.
-//     $ go build -buildmode=plugin -ldflags "-X 'main.flags=-opt val'" uaa/plugin/uaa
+//     $ go build -buildmode=plugin -ldflags "-X 'main.flags=-opt val'" niller/plugin/niller
 var flags string
 
 // AnalyzerPlugin provides analyzers as a plugin.

--- a/testdata/src/a/a.go
+++ b/testdata/src/a/a.go
@@ -9,53 +9,35 @@ func (t *Test) test() int {
 	return 1
 }
 
-func CreateTest(flag bool) *Test {
-	if flag {
-		return &Test{}
-	} else {
-		return nil
-	}
-}
-
-func CreateTestWithErr(flag bool) (*Test, error) {
-	if flag {
+func CreateTest(cond bool) (*Test, error) {
+	if cond {
 		return &Test{}, nil
 	} else {
 		return nil, errors.New("err")
 	}
 }
 
-func hogefuga() (a, b int, c int){
-	return 1, 1, 1
-}
-
-
 func f() interface{} {
 	var a = &Test{}
 	var b *Test
-	var t = CreateTest(true)
-	if t == nil {
-		panic("")
-	}
-	var s = CreateTest(true)
-	var aa, ab, ac = hogefuga()
-	var (
-		e *Test
-		f *Test
-	)
-	g := CreateTest(true)
-	h, err := CreateTestWithErr(true)
+	c, _ := CreateTest(true)
+	d, err := CreateTest(true)
 	if err != nil {
 		return err
 	}
+	var e *Test
+	if e, err = CreateTest(true); err != nil {
+		return err
+	}
+	var (
+		f *Test
+	)
 
-	x := a.test()
-	y := b.test() // want "b may be nil"
-	xx := t.test()
-	xy := e.test() // want "e may be nil"
-	xz := f.test() // want "f may be nil"
-	yx := s.test() // want "s may be nil"
-	ga := g.test() // want "g may be nil"
-	gb := h.test()
-	return x + y + xx + aa + ab + ac + xy + xz + yx + ga + gb
+	a.test()
+	b.test() // want "b may be nil"
+	c.test() // want "c may be nil"
+	d.test()
+	e.test()
+	f.test() // want "f may be nil"
+	return nil
 }

--- a/testdata/src/a/a.go
+++ b/testdata/src/a/a.go
@@ -32,6 +32,11 @@ func f() interface{} {
 	var (
 		f *Test
 	)
+	/*
+	var g *Test
+	g = &Test{}
+	g.test()
+	*/
 
 	a.test()
 	b.test() // want "b may be nil"
@@ -39,5 +44,6 @@ func f() interface{} {
 	d.test()
 	e.test()
 	f.test() // want "f may be nil"
+
 	return nil
 }

--- a/testdata/src/a/a.go
+++ b/testdata/src/a/a.go
@@ -3,10 +3,11 @@ package a
 import "errors"
 
 type Test struct {
+	val int
 }
 
 func (t *Test) test() int {
-	return 1
+	return t.val
 }
 
 func CreateTest(cond bool) (*Test, error) {

--- a/testdata/src/a/a.go
+++ b/testdata/src/a/a.go
@@ -32,6 +32,9 @@ func f() interface{} {
 	var (
 		f *Test
 	)
+	var g *Test
+	g = &Test{}
+	g.test()
 
 	a.test()
 	b.test() // want "b may be nil"
@@ -39,5 +42,6 @@ func f() interface{} {
 	d.test()
 	e.test()
 	f.test() // want "f may be nil"
+
 	return nil
 }

--- a/testdata/src/a/a.go
+++ b/testdata/src/a/a.go
@@ -1,5 +1,7 @@
 package a
 
+import "errors"
+
 type Test struct {
 }
 
@@ -12,6 +14,14 @@ func CreateTest(flag bool) *Test {
 		return &Test{}
 	} else {
 		return nil
+	}
+}
+
+func CreateTestWithErr(flag bool) (*Test, error) {
+	if flag {
+		return &Test{}, nil
+	} else {
+		return nil, errors.New("err")
 	}
 }
 
@@ -33,11 +43,19 @@ func f() interface{} {
 		e *Test
 		f *Test
 	)
+	g := CreateTest(true)
+	h, err := CreateTestWithErr(true)
+	if err != nil {
+		return err
+	}
+
 	x := a.test()
 	y := b.test() // want "b may be nil"
 	xx := t.test()
 	xy := e.test() // want "e may be nil"
 	xz := f.test() // want "f may be nil"
 	yx := s.test() // want "s may be nil"
-	return x + y + xx + aa + ab + ac + xy + xz + yx
+	ga := g.test() // want "g may be nil"
+	gb := h.test()
+	return x + y + xx + aa + ab + ac + xy + xz + yx + ga + gb
 }

--- a/testdata/src/a/a.go
+++ b/testdata/src/a/a.go
@@ -7,10 +7,37 @@ func (t *Test) test() int {
 	return 1
 }
 
+func CreateTest(flag bool) *Test {
+	if flag {
+		return &Test{}
+	} else {
+		return nil
+	}
+}
+
+func hogefuga() (a, b int, c int){
+	return 1, 1, 1
+}
+
+
 func f() interface{} {
 	var a = &Test{}
 	var b *Test
+	var t = CreateTest(true)
+	if t == nil {
+		panic("")
+	}
+	var s = CreateTest(true)
+	var aa, ab, ac = hogefuga()
+	var (
+		e *Test
+		f *Test
+	)
 	x := a.test()
 	y := b.test() // want "b may be nil"
-	return x + y
+	xx := t.test()
+	xy := e.test() // want "e may be nil"
+	xz := f.test() // want "f may be nil"
+	yx := s.test() // want "s may be nil"
+	return x + y + xx + aa + ab + ac + xy + xz + yx
 }


### PR DESCRIPTION
# Overview

nil pointer dereferenceが発生するような危険なコードに対して警告を発生させる（コーナーケースに関しては順次対応予定）

## example 
```go
package main

import "errors"

type Test struct { val int }

func (t *Test) test() int { return t.val }

func CreateTest(cond bool) (*Test, error) {
	if cond {
		return &Test{}, nil
	} else {
		return nil, errors.New("err")
	}
}

func main() {
	var a = &Test{}
	var b *Test
	c, _ := CreateTest(true)
	d, err := CreateTest(true)
	if err != nil {
		return
	}
	var e *Test
	if e, err = CreateTest(true); err != nil {
		return
	}
	var (
		f *Test
	)

	a.test()
	b.test() // warns "b may be nil"
	c.test() // warns "c may be nil" (errのチェックをスキップしている場合は警告を出す)
	d.test() // (errをチェックしている場合は呼び出し関数の実装を信用し警告を出さない)
	e.test() // (同上)
	f.test() // warns "f may be nil"
}
```

# Known issues
#1 #3 