### PR TITLE
partially resolved #1

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2020 Taiyo Mizuhashi
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/testdata/src/a/a.go
+++ b/testdata/src/a/a.go
@@ -33,11 +33,13 @@ func f() interface{} {
 	var (
 		f *Test
 	)
-	/*
+
 	var g *Test
 	g = &Test{}
-	g.test()
-	*/
+
+	var h *Test
+	h = &Test{}
+	h = nil
 
 	a.test()
 	b.test() // want "b may be nil"
@@ -45,6 +47,8 @@ func f() interface{} {
 	d.test()
 	e.test()
 	f.test() // want "f may be nil"
+	g.test()
+	h.test() // want "h may be nil"
 
 	return nil
 }


### PR DESCRIPTION
ASTの走査順で再代入をチェックすることにより #1 を部分的に解決

```go
package a

import "errors"

type Test struct {
	val int
}

func (t *Test) test() int {
	return t.val
}

func CreateTest(cond bool) (*Test, error) {
	if cond {
		return &Test{}, nil
	} else {
		return nil, errors.New("err")
	}
}

func f() interface{} {
	var a = &Test{}
	var b *Test
	c, _ := CreateTest(true)
	d, err := CreateTest(true)
	if err != nil {
		return err
	}
	var e *Test
	if e, err = CreateTest(true); err != nil {
		return err
	}
	var (
		f *Test
	)

// new case
	var g *Test
	g = &Test{}

	var h *Test
	h = &Test{}
	h = nil
//

	a.test()
	b.test() // want "b may be nil"
	c.test() // want "c may be nil"
	d.test()
	e.test()
	f.test() // want "f may be nil"
	g.test()
	h.test() // want "h may be nil"

	return nil
}
```